### PR TITLE
add definitions for php print_r, var_dump, and serialize formats

### DIFF
--- a/Highlight/languages/php-printr.json
+++ b/Highlight/languages/php-printr.json
@@ -1,0 +1,78 @@
+{
+   "keywords" : {
+       "keyword": "Array Object",
+       "literal" : "true false yes no null"
+   },
+   "contains" : [
+      {
+         "className" : "attr",
+         "variants" : [
+            {
+               "begin" : "\\[[a-zA-Z_0-9]*\\]"
+            }
+         ]
+      },
+      {
+         "relevance" : 10,
+         "className" : "meta",
+         "begin" : "=>"
+      },
+      {
+         "end" : "^[ \\-]*[a-zA-Z_][\\w\\-]*:",
+         "returnEnd" : true,
+         "contains" : [
+            {
+               "relevance" : 0,
+               "begin" : "\\\\[\\s\\S]"
+            }
+         ],
+         "begin" : "[\\|>] *$",
+         "className" : "string"
+      },
+      {
+         "begin" : "&[a-zA-Z_]\\w*$",
+         "className" : "meta"
+      },
+      {
+         "className" : "meta",
+         "begin" : "\\*[a-zA-Z_]\\w*$"
+      },
+      {
+         "className" : "literal",
+         "begin" : "(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)[\\n]",
+         "relevance" : 0
+      },
+      {
+         "className" : "section",
+         "begin" : "Array"
+      },
+      
+      {
+         "relevance" : 0,
+         "className" : "string",
+         "variants" : [
+            {
+               "end" : "'",
+               "begin" : "'"
+            },
+            {
+               "end" : "\"",
+               "begin" : "\""
+            },
+            {
+               "begin" : "\\S+"
+            }
+         ],
+         "contains" : {
+            "$ref" : "#contains.2.contains"
+         }
+      }      
+   ],
+   "case_insensitive" : false,
+   "aliases" : [
+      "printr",
+      "print_r",
+      "php-printr",
+      "php-print_r"
+   ]
+}

--- a/Highlight/languages/php-serialize.json
+++ b/Highlight/languages/php-serialize.json
@@ -1,0 +1,73 @@
+{
+    "contains": [
+        {
+            "className": "string",
+            "begin": "\"",
+            "end": "\"",
+            "illegal": "\\n",
+            "contains": [
+                {
+                    "begin": "\\\\[\\s\\S]",
+                    "relevance": 0
+                }
+            ]
+        },
+        {
+            "className": "number",
+            "begin": "(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",
+            "relevance": 0
+        },
+        {
+            "begin": "{",
+            "end": "}",
+            "contains": [
+                {
+                    "className": "attr",
+                    "begin": "\"",
+                    "end": "\"",
+                    "contains": [
+                        {
+                            "$ref": "#contains.0.contains.0"
+                        }
+                    ],
+                    "illegal": "\\n"
+                },
+                {
+                    "end": ",",
+                    "endsWithParent": true,
+                    "excludeEnd": true,
+                    "contains": {
+                        "$ref": "#contains"
+                    },
+                    "keywords": {
+                        "literal": "true false null"
+                    },
+                    "begin": ":"
+                }
+            ],
+            "illegal": "\\S"
+        },
+        {
+            "begin": "\\[",
+            "end": "\\]",
+            "contains": [
+                {
+                    "end": ",",
+                    "endsWithParent": true,
+                    "excludeEnd": true,
+                    "contains": {
+                        "$ref": "#contains"
+                    },
+                    "keywords": {
+                        "$ref": "#contains.2.contains.1.keywords"
+                    }
+                }
+            ],
+            "illegal": "\\S"
+        }
+    ],
+    "keywords": {
+        "$ref": "#contains.2.contains.1.keywords"
+    },
+    "illegal": "\\S"
+}

--- a/Highlight/languages/php-vardump.json
+++ b/Highlight/languages/php-vardump.json
@@ -1,0 +1,54 @@
+{
+    "contains": [
+        {
+            "className": "string",
+            "begin": "'",
+            "end": "'",
+            "illegal": "\\n",
+            "contains": [
+                {
+                    "begin": "\\\\[\\s\\S]",
+                    "relevance": 0
+                }
+            ]
+        },
+        {
+            "className": "number",
+            "begin": "(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",
+            "relevance": 0
+        },
+        {
+            "begin": "\\(",
+            "end": "\\)",
+            "contains": [
+                {
+                    "className": "attr",
+                    "begin": "'",
+                    "end": "'",
+                    "contains": [
+                        {
+                            "$ref": "#contains.0.contains.0"
+                        }
+                    ]
+                },
+                {
+                    "end": ",",
+                    "endsWithParent": true,
+                    "excludeEnd": true,
+                    "contains": {
+                        "$ref": "#contains"
+                    },
+                    "keywords": {
+                        "literal": "true false null"
+                    },
+                    "begin": "=>"
+                }
+            ],
+            "illegal": "\\S"
+        }
+    ],
+    "keywords": {
+        "$ref": "#contains.2.contains.1.keywords"
+    },
+    "illegal": "\\S"
+}


### PR DESCRIPTION
Here are some php specific lang definitions.   These are only lightly tested.    notes:

* Serialize is a direct copy of json.json.   The syntax is close enough that It seems to "just work".
* var_dump is derived from json.json with various modifications.
* print_r is derived from yaml.json with heavy mods.

I don't pretend to totally understand the use of classNames in highlight.js, but I got all three to print out same/similar colors in the CLI when serialized from the same complex/nested array data source.

Doubtless many improvements could be made, but it is a starting point for highlighting these three popular php serialization formats.