### PR TITLE
fix for strings that begin with a number like 123ewqeqrs.

### DIFF
--- a/Highlight/languages/yaml.json
+++ b/Highlight/languages/yaml.json
@@ -1,1 +1,129 @@
-{"case_insensitive":true,"aliases":["yml","YAML","yaml"],"contains":[{"className":"attr","variants":[{"begin":"^[ \\-]*[a-zA-Z_][\\w\\-]*:"},{"begin":"^[ \\-]*\"[a-zA-Z_][\\w\\-]*\":"},{"begin":"^[ \\-]*'[a-zA-Z_][\\w\\-]*':"}]},{"className":"meta","begin":"^---s*$","relevance":10},{"className":"string","begin":"[\\|>] *$","returnEnd":true,"contains":[{"begin":"\\\\[\\s\\S]","relevance":0},{"className":"template-variable","variants":[{"begin":"{{","end":"}}"},{"begin":"%{","end":"}"}]}],"end":"^[ \\-]*[a-zA-Z_][\\w\\-]*:"},{"begin":"<%[%=-]?","end":"[%-]?%>","subLanguage":"ruby","excludeBegin":true,"excludeEnd":true,"relevance":0},{"className":"type","begin":"![a-zA-Z_]\\w*"},{"className":"type","begin":"!![a-zA-Z_]\\w*"},{"className":"meta","begin":"&[a-zA-Z_]\\w*$"},{"className":"meta","begin":"\\*[a-zA-Z_]\\w*$"},{"className":"bullet","begin":"^ *-","relevance":0},{"className":"comment","begin":"#","end":"$","contains":[{"begin":"\\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\\b"},{"className":"doctag","begin":"(?:TODO|FIXME|NOTE|BUG|XXX):","relevance":0}]},{"beginKeywords":"true false yes no null","keywords":{"literal":"true false yes no null"}},{"className":"number","begin":"(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)","relevance":0},{"className":"string","relevance":0,"variants":[{"begin":"'","end":"'"},{"begin":"\"","end":"\""},{"begin":"\\S+"}],"contains":{"$ref":"#contains.2.contains"}}]}
+{
+   "aliases" : [
+      "yml",
+      "YAML",
+      "yaml"
+   ],
+   "contains" : [
+      {
+         "variants" : [
+            {
+               "begin" : "^[ \\-]*[a-zA-Z_][\\w\\-]*:"
+            },
+            {
+               "begin" : "^[ \\-]*\"[a-zA-Z_][\\w\\-]*\":"
+            },
+            {
+               "begin" : "^[ \\-]*'[a-zA-Z_][\\w\\-]*':"
+            }
+         ],
+         "className" : "attr"
+      },
+      {
+         "className" : "meta",
+         "relevance" : 10,
+         "begin" : "^---s*$"
+      },
+      {
+         "begin" : "[\\|>] *$",
+         "contains" : [
+            {
+               "begin" : "\\\\[\\s\\S]",
+               "relevance" : 0
+            },
+            {
+               "variants" : [
+                  {
+                     "end" : "}}",
+                     "begin" : "{{"
+                  },
+                  {
+                     "end" : "}",
+                     "begin" : "%{"
+                  }
+               ],
+               "className" : "template-variable"
+            }
+         ],
+         "className" : "string",
+         "end" : "^[ \\-]*[a-zA-Z_][\\w\\-]*:",
+         "returnEnd" : true
+      },
+      {
+         "excludeEnd" : true,
+         "excludeBegin" : true,
+         "end" : "[%-]?%>",
+         "begin" : "<%[%=-]?",
+         "subLanguage" : "ruby",
+         "relevance" : 0
+      },
+      {
+         "begin" : "![a-zA-Z_]\\w*",
+         "className" : "type"
+      },
+      {
+         "begin" : "!![a-zA-Z_]\\w*",
+         "className" : "type"
+      },
+      {
+         "begin" : "&[a-zA-Z_]\\w*$",
+         "className" : "meta"
+      },
+      {
+         "begin" : "\\*[a-zA-Z_]\\w*$",
+         "className" : "meta"
+      },
+      {
+         "className" : "bullet",
+         "relevance" : 0,
+         "begin" : "^ *-"
+      },
+      {
+         "end" : "$",
+         "begin" : "#",
+         "contains" : [
+            {
+               "begin" : "\\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\\b"
+            },
+            {
+               "begin" : "(?:TODO|FIXME|NOTE|BUG|XXX):",
+               "className" : "doctag",
+               "relevance" : 0
+            }
+         ],
+         "className" : "comment"
+      },
+      {
+         "keywords" : {
+            "literal" : "true false yes no null"
+         },
+         "beginKeywords" : "true false yes no null"
+      },
+      {
+         "begin" : "(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)[,\\n]",
+         "className" : "number",
+         "relevance" : 0
+      },
+      {
+         "relevance" : 0,
+         "className" : "string",
+         "variants" : [
+            {
+               "begin" : "'",
+               "end" : "'"
+            },
+            {
+               "end" : "\"",
+               "begin" : "\""
+            },
+            {
+               "begin" : "\\S+"
+            }
+         ],
+         "contains" : {
+            "$ref" : "#contains.2.contains"
+         }
+      }
+   ],
+   "case_insensitive" : true
+}


### PR DESCRIPTION
Previously the 123 was displaying as a number, not as part of the string.  

Also, I pretty-printed the json so it is readable and easily edited, instead of all on one line.

This is really only a one-line change to the regex in the number class.   It changed from:

         "begin" : "(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",

to:

         "begin" : "(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)[,\\n]",
