### PR TITLE
Implements a default color scheme for the CLI.  

### DIFF
--- a/Highlight/Decorator/CliDecorator.php
+++ b/Highlight/Decorator/CliDecorator.php
@@ -21,7 +21,7 @@ class CliDecorator implements Decorator
      */
     public function __construct(array $colorMap = [])
     {
-        $this->colorMap = $colorMap;
+        $this->colorMap = $this->getColorScheme($colorMap);
 
         //Some required defaults
 //        if (empty($this->colorMap['document'])) {
@@ -32,6 +32,38 @@ class CliDecorator implements Decorator
             $this->colorMap['default'] = Colors::WHITE;
         }
     }
+    
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    private function getColorScheme(array $colorMap): array
+    {
+        $colorScheme = [
+            'document' => 'light_white',
+            'section' => 'green',
+            'keyword' => 'green',
+            'class'  => 'green',
+            'attr'   => 'red',
+            'bullet'   => 'red',
+            'string' => 'light_blue',
+            'number' => 'light_red',
+            'literal' => 'yellow',
+            'meta' => 'blue',
+            'comments'   => 'gray',
+        ];
+        
+        $colorScheme = $colorMap + $colorScheme;    // duplicate keys in $colorScheme ignored.
+        
+        //Normalize colors
+        foreach ($colorScheme as &$colorName) {
+            $colorName = Colors::normalizeColor($colorName);
+        }
+
+        return $colorScheme;
+    }
+    
 
     /**
      * @param string $nodeType


### PR DESCRIPTION
so far, this has only been tested with json, yaml, php-vardump, php-printr, php-serialize.  Other langs especially markup like html/xml not yet implemented or tested.

The approach taken here is to create a default color scheme that works for the CLI across all supported langs.  Any of the class names can be overridden by the caller to use a custom scheme, so it is still compatible with eg cli-highlight classes.

The main goals here are to:

* have a single color scheme that works across various langs without having to define new classes or colors for each lang (as per cli-highlight).
*  have a default scheme right in highlight.php, so that no additional packages are needed.